### PR TITLE
replace escape with encodeURIComponent for POST data

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ exports.request = function (options, callback) {
     if (options.data && typeof options.data === 'object') {
         var data = [];
         for (var key in options.data) {
-            data.push(escape(key) + '=' + escape(options.data[key]));
+            data.push(encodeURIComponent(key) + '=' + encodeURIComponent(options.data[key]));
         }
         options.data = data.join('&');
     }


### PR DESCRIPTION
In your POST data parsing you're using escape(), which was causing failure for some special characters, including foreign alphabet letters. Using encodeURIComponent instead solves the problem.

http://stackoverflow.com/questions/75980/best-practice-escape-or-encodeuri-encodeuricomponent

Thanks for the great module!
