### PR TITLE
Mocha was detecting a global leak

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,7 +249,7 @@ exports.request = function (options, callback) {
     }
 
     //Spawn the process
-    child = spawn(cmd, args, { cwd: options.cwd || cwd }, function (curl) {
+    var child = spawn(cmd, args, { cwd: options.cwd || cwd }, function (curl) {
 
         //Collect stdout
         curl.stdout.on('data', function (data) {


### PR DESCRIPTION
Fixed this by adding the 'var' keyword to the 'child' variable.  Please have a look, thanks!
