### PR TITLE
Update readme by adding curl_path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ string to write stderr to a file.
 Useful if you want to see what curl command is to be executed without actually
 making the request
 
+`curl_path` - *default: 'curl'*
+
+Use this if you want to use curlrequest in Windows or if you want to specify anothr path for curl.
+
 ```javascript
 curl.request({ url: 'http://google.com', pretend: true }, function (err, stdout, meta) {
     console.log('%s %s', meta.cmd, meta.args.join(' '));


### PR DESCRIPTION
I needed to use this module on a Windows machine. This option `curl_path` was useful, however, I coudn't find it without reading issues and diving in sourcecode.

This pull request adds `curl_path` to readme.md