### PR TITLE
update error messages for require and require_not

### DIFF
--- a/index.js
+++ b/index.js
@@ -293,7 +293,7 @@ exports.request = function (options, callback) {
                         }
                     }
                     if (!valid) {
-                        err = 'response does not contain required string(s)';
+                        err = 'response does not contain required string: ' + require_str[i];
                         stdout = null
                     } else if (!encoding) {
                         stdout = new Buffer(stdout);
@@ -312,7 +312,7 @@ exports.request = function (options, callback) {
                         }
                     }
                     if (!valid) {
-                        err = 'response contains bad string(s)';
+                        err = 'response contains bad string: ' + require_not_str[i];
                         stdout = null
                     } else if (!encoding) {
                         stdout = new Buffer(stdout);


### PR DESCRIPTION
Hi there,

This commit enhance the error message that occur if one or more required strings were missing or some not_required strings were contained in stdout.

I hope this is useful.