### PR TITLE
Fix the last commit

### DIFF
--- a/index.js
+++ b/index.js
@@ -293,7 +293,7 @@ exports.request = function (options, callback) {
                         }
                     }
                     if (!valid) {
-                        err = 'response does not contain required string: ' + require_str[i];
+                        err = 'response does not contain required string: ' + require_str[--i];
                         stdout = null
                     } else if (!encoding) {
                         stdout = new Buffer(stdout);
@@ -312,7 +312,7 @@ exports.request = function (options, callback) {
                         }
                     }
                     if (!valid) {
-                        err = 'response contains bad string: ' + require_not_str[i];
+                        err = 'response contains bad string: ' + require_not_str[--i];
                         stdout = null
                     } else if (!encoding) {
                         stdout = new Buffer(stdout);


### PR DESCRIPTION
Hi there,

Ahem! In the last pull request (Which was merged already) I was trying to enhance the error messages in case of failure due to (require or require_not) options. However, there is a little mistake in getting the failed string (actually it gets the next string in the array, or undefined).

It is fixed in this commit. I double tested it. And I'm sorry for the previous mistake.